### PR TITLE
correccion validacion, cantidad dias precisos

### DIFF
--- a/app/src/main/java/com/example/superandome_appfinal/Daos/EncuestaUsuarioDaoImpl.java
+++ b/app/src/main/java/com/example/superandome_appfinal/Daos/EncuestaUsuarioDaoImpl.java
@@ -27,20 +27,10 @@ public class EncuestaUsuarioDaoImpl extends BaseDaoImpl<EncuestaUsuario, Integer
     
     @Override
     public List<EncuestaUsuario> getEncuestaUsuarioById(Integer idEncuesta, Integer idUsuario) throws SQLException {
-
         Map<String, Object> filtros = new HashMap<>();
         filtros.put("idEncuesta", idEncuesta);
         filtros.put("idUsuario", idUsuario);
 
-        try {
-            List<EncuestaUsuario> list = queryForFieldValues(filtros);
-            if (list != null && list.size() > 0)
-                return list;
-            return null;
-        } catch (SQLException throwables) {
-            throwables.printStackTrace();
-        }
-
-        return null;
+        return queryForFieldValues(filtros);
     }
 }

--- a/app/src/main/java/com/example/superandome_appfinal/Dialogos/dialogoEsperarXDias.java
+++ b/app/src/main/java/com/example/superandome_appfinal/Dialogos/dialogoEsperarXDias.java
@@ -14,11 +14,15 @@ import androidx.fragment.app.DialogFragment;
 
 import com.example.superandome_appfinal.R;
 
-public class dialogoesperar7dias extends DialogFragment {
+import java.text.MessageFormat;
+
+public class dialogoEsperarXDias extends DialogFragment {
     Activity actividad;
     TextView txtEstatus, txtMensaje, btnAceptar;
+    Long dias;
 
-    public dialogoesperar7dias() {
+    public dialogoEsperarXDias(long dias) {
+        this.dias = dias;
     }
 
     @NonNull
@@ -30,19 +34,21 @@ public class dialogoesperar7dias extends DialogFragment {
     private AlertDialog crearDialogo(){
         AlertDialog.Builder builder  = new AlertDialog.Builder(getActivity());
         LayoutInflater inflater = getActivity().getLayoutInflater();
-        View v = inflater.inflate(R.layout.fragment_dialogo_esperar7dias,null);
+        View v = inflater.inflate(R.layout.fragment_dialogo_esperarxdias,null);
         builder.setView(v);
 
         txtEstatus = (TextView) v.findViewById(R.id.txtEstatus);
         txtMensaje = (TextView) v.findViewById(R.id.txtMensajeDialogo);
         btnAceptar = (TextView) v.findViewById(R.id.btnAceptarDialogCambioPass);
 
-        btnAceptar.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                dismiss();
-            }
-        });
+        String textoDias = MessageFormat.format("" +
+                        "{0} {1}",
+                        dias.toString(),
+                        dias == 1 ? "día" : "días");
+        String mensajeDias = txtMensaje.getText().toString().replace("#DIAS#", textoDias);
+        txtMensaje.setText(mensajeDias);
+
+        btnAceptar.setOnClickListener(v1 -> dismiss());
 
         return builder.create();
     }
@@ -50,9 +56,9 @@ public class dialogoesperar7dias extends DialogFragment {
     @Override
     public void onAttach(@NonNull Context context) {
         super.onAttach(context);
-        if(context instanceof Activity){
-            this.actividad  = (Activity) context;
-        }else{
+        if (context instanceof Activity) {
+            this.actividad = (Activity) context;
+        } else {
             throw new RuntimeException(context.toString());
         }
     }

--- a/app/src/main/java/com/example/superandome_appfinal/Vistas/Consultante/indexEncuestas.java
+++ b/app/src/main/java/com/example/superandome_appfinal/Vistas/Consultante/indexEncuestas.java
@@ -12,14 +12,12 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
-import android.widget.Toast;
 
 import com.example.superandome_appfinal.Constantes.EncuestaEnum;
-import com.example.superandome_appfinal.Dialogos.dialogoEmocionxdia;
 import com.example.superandome_appfinal.Dialogos.dialogoErrorFragment;
 import com.example.superandome_appfinal.Dialogos.dialogoErrorInesperado;
 import com.example.superandome_appfinal.Dialogos.dialogoProximamente;
-import com.example.superandome_appfinal.Dialogos.dialogoesperar7dias;
+import com.example.superandome_appfinal.Dialogos.dialogoEsperarXDias;
 import com.example.superandome_appfinal.Entidades.Encuesta;
 import com.example.superandome_appfinal.Entidades.EncuestaUsuario;
 import com.example.superandome_appfinal.Helpers.SessionManager;
@@ -44,6 +42,7 @@ public class indexEncuestas extends Fragment {
     EncuestaUsuarioService encuestaUsuService;
 
     Integer idUsuario;
+    long dias;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -90,7 +89,7 @@ public class indexEncuestas extends Fragment {
             int idEncuesta = encuestas.get(recyclerViewEncuestas.getChildAdapterPosition(view)).getIdEncuesta();
 
             if (!puedeContestar(idEncuesta)) {
-                dialogoesperar7dias d = new dialogoesperar7dias();
+                dialogoEsperarXDias d = new dialogoEsperarXDias(dias);
                 d.show(getActivity().getSupportFragmentManager(), "fragment_dialogo_esperar7dias");
                 return;
             }
@@ -123,9 +122,10 @@ public class indexEncuestas extends Fragment {
 
         List<EncuestaUsuario> listEncuestaUsuario = encuestaUsuService.getEncuestaUsuarioById(idEncuesta, idUsuario);
 
-        if (listEncuestaUsuario == null) {
+        if (listEncuestaUsuario == null)
+            throw new Exception("Ha ocurrido un error al buscar las encuestas del usuario");
+        if (listEncuestaUsuario.size() == 0)
             return true;
-        }
 
         EncuestaUsuario encuestaUsu = listEncuestaUsuario.get(listEncuestaUsuario.size() -1);
 
@@ -134,8 +134,10 @@ public class indexEncuestas extends Fragment {
         Date fechaActualFormat = formatter.parse(formatter.format(new Date()));
 
         long diff = fechaActualFormat.getTime() - ultimaEncuestaFormat.getTime();
-        long dias = TimeUnit.DAYS.convert(diff, TimeUnit.MILLISECONDS);
+        long diferenciaDias = TimeUnit.DAYS.convert(diff, TimeUnit.MILLISECONDS);
 
-        return dias >= 7;
+        dias = 7 - diferenciaDias;
+
+        return diferenciaDias >= 7;
     }
 }

--- a/app/src/main/res/vistas/consultante/layout/fragment_dialogo_esperarxdias.xml
+++ b/app/src/main/res/vistas/consultante/layout/fragment_dialogo_esperarxdias.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".Dialogos.dialogoesperar7dias">
+    tools:context=".Dialogos.dialogoEsperarXDias">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
@@ -15,7 +15,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:fontFamily="@font/cambay"
-            android:text="Para volver a realizar esta encuesta, debes esperar 7 días."
+            android:text="Para volver a realizar esta encuesta, debes esperar #DIAS#."
             android:textAlignment="center"
             android:textColor="@color/black"
             android:textSize="22sp"


### PR DESCRIPTION
se corrigió la validación de encuesta, para distinguir entre encuesta no contestada y error de bd.
se cambió el texto de esperar días para que sea dinámico según la cantidad de días que quedan.